### PR TITLE
fix: avoid calling .map on undefined for array selector

### DIFF
--- a/packages/ss-search/src/index.ts
+++ b/packages/ss-search/src/index.ts
@@ -28,7 +28,7 @@ export const convertToSearchableStrings = memoize(<T>(elements: T[], searchableK
                     const arraySelector = get(arraySelectorRegex.exec(key), "1")
 
                     const value = get(element, key.replace(arraySelectorRegex, ""))
-                    if (!arraySelector && (value === null || value === undefined || typeof value === "function")) {
+                    if (value === null || value === undefined || typeof value === "function") {
                         return ""
                     }
 

--- a/packages/ss-search/tests/convertToSearchableStrings.test.ts
+++ b/packages/ss-search/tests/convertToSearchableStrings.test.ts
@@ -155,7 +155,11 @@ describe("index", function () {
             // Arrange
             const data = [
                 {
+                    object: { nestedProperty: "value" },
                     array: [{ prop1: "value1", prop2: "value2" }],
+                },
+                {
+                    object: { nestedProperty: "value" },
                 },
             ]
             const keys = ["array[prop2]"]
@@ -164,7 +168,7 @@ describe("index", function () {
             const actual = convertToSearchableStrings(data, keys)
 
             // Assert
-            expect(actual).to.be.eql(["value2"])
+            expect(actual).to.be.eql(["value2", ""])
         })
 
         it("Should return empty string when the elements value provided is not an object", function () {


### PR DESCRIPTION
Here's my attempt at fixing #37. 

Let me know if this condition was used for some other case and what I can do better!
