### PR TITLE
Change package type to `module`

### DIFF
--- a/ss-search/package.json
+++ b/ss-search/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "lodash": "4.17.21"
   },
-  "type": "commonjs",
+  "type": "module",
   "main": "./index.cjs",
   "module": "./index.js"
 }


### PR DESCRIPTION
With package type: `commonjs` it throws error when compiling on modern JS projects.